### PR TITLE
Update node_helper.js

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -41,7 +41,7 @@ module.exports = NodeHelper.create({
       } else {
 
         //make request to OpenWeather One Call API
-        var url = "https://api.openweathermap.org/data/2.5/onecall?" +
+        var url = "https://api.openweathermap.org/data/3.0/onecall?" +
           "lat=" + payload.latitude +
           "&lon=" + payload.longitude +
           "&exclude=" + "minutely" +


### PR DESCRIPTION
openweather api 2.5 is no longer available. updates to use the 3.0 endpoint.  Users may need to get a 3.0 api key.