### PR TITLE
Update node_helper.js

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -41,7 +41,7 @@ module.exports = NodeHelper.create({
       } else {
 
         //make request to OpenWeather One Call API
-        var url = "https://api.openweathermap.org/data/2.5/onecall?" +
+        var url = "https://api.openweathermap.org/data/3.0/onecall?" +
           "lat=" + payload.latitude +
           "&lon=" + payload.longitude +
           "&exclude=" + "minutely" +


### PR DESCRIPTION
Updated the deprecated OpenWeather v2.5 URL to v3.0. The new version is backwards compatible.

It is also necessary to sign up to the OpenWeather v3.0 API with a Credit Card as when using more than 1000 requests per day there will be charges.